### PR TITLE
Implemented a Typescript definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,13 @@ split it into 4 children cells and put them in the queue.
 It will be guaranteed to be a global optimum within the given precision.
 
 ![image](https://cloud.githubusercontent.com/assets/25395/16748630/e6b3336c-47cd-11e6-8059-0eeccf22cf6b.png)
+
+### TypeScript
+
+TypeScript implementation was added to the [DefinitelyTyped repository](https://github.com/DefinitelyTyped/DefinitelyTyped).
+
+**Install definition**
+
+```bash
+$ typings install --save --global dt~polylabel
+```


### PR DESCRIPTION
Please review typescript definition @mourner.
Added JSDocs to definition @tmcw must be happy :)

Importing polylabel with Typescript looks like this:

```javascript
import polylabel = require('polylabel')
```

It would be nice to define the default module to make it the import look like this.

```javascript
import polylabel from polylabel
// OR
import * as polylabel from polylabel
```

The JSDocs outputs pretty well using VS Code or Atom.
![image](https://cloud.githubusercontent.com/assets/550895/18114902/f56b7eac-6f08-11e6-9f37-725b40fa106b.png)

