### PR TITLE
Add default module export to support ES6 Typescript

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var Queue = require('tinyqueue');
 
 module.exports = polylabel;
+module.exports.default = polylabel;
 
 function polylabel(polygon, precision, debug) {
     precision = precision || 1.0;


### PR DESCRIPTION
### Typescript 

This enables a more ES6 import syntax used in Typescript.

**current**

```javascript
import * as polylabel from 'polylabel'
```

**with default module**

```javascript
import polylabel from 'polylabel'
```

### Babel

Babel does compile the default module without this addition, however it does some hacks in the background.

**sample code**
```javascript
import polylabel from 'polylabel';

const polygon = [[[3116,3071],[3118,3068],[3108,3102],[3751,927]]]
polylabel(polygon)
```

**babel converts into**
```javascript
var _polylabel = require('polylabel');

var _polylabel2 = _interopRequireDefault(_polylabel);

function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
var polygon = [[[3116, 3071], [3118, 3068], [3108, 3102], [3751, 927]]]; 
(0, _polylabel2.default)(polygon);
```