### PR TITLE
add link to unofficial python implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ int main() {
 ### Command Line Usage
 
 An external utility can be found at https://github.com/andrewharvey/geojson-polygon-labels
+
+### Python alternative
+
+Unofficial implementation for Python at https://github.com/Twista/python-polylabel

--- a/README.md
+++ b/README.md
@@ -59,10 +59,7 @@ int main() {
 }
 ```
 
-### Command Line Usage
+#### Ports to other languages
 
-An external utility can be found at https://github.com/andrewharvey/geojson-polygon-labels
-
-### Python alternative
-
-Unofficial implementation for Python at https://github.com/Twista/python-polylabel
+- [andrewharvey/geojson-polygon-labels](https://github.com/andrewharvey/geojson-polygon-labels) (CLI) 
+- [Twista/python-polylabel](https://github.com/Twista/python-polylabel) (Python)


### PR DESCRIPTION
Hello,

First, thanks for the library - its awesome (using JS version for some time) - Few months ago I made port to the python and thought it could be handy to mention the link in Readme. The implementation is 1:1 to your code (same tests w/ same results) and supports both, Python 2 and 3. 


