### PR TITLE
Add link in readme to R implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,4 @@ int main() {
 - [andrewharvey/geojson-polygon-labels](https://github.com/andrewharvey/geojson-polygon-labels) (CLI) 
 - [Twista/python-polylabel](https://github.com/Twista/python-polylabel) (Python)
 - [Shapely](https://github.com/Toblerity/Shapely/blob/master/shapely/algorithms/polylabel.py) (Python)
+- [polylabelr](https://CRAN.R-project.org/package=polylabelr) (R)


### PR DESCRIPTION
This small pull requests adds a link in the readme to an R package, polylabelr, which is an implementation of the polylabel c++ library.