### PR TITLE
Adding polylabel-rs (Rust port) to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,4 @@ int main() {
 - [Twista/python-polylabel](https://github.com/Twista/python-polylabel) (Python)
 - [Shapely](https://github.com/Toblerity/Shapely/blob/master/shapely/algorithms/polylabel.py) (Python)
 - [polylabelr](https://CRAN.R-project.org/package=polylabelr) (R)
+- [polylabel-rs](https://github.com/urschrei/polylabel-rs) (Rust)


### PR DESCRIPTION
Just discovered this package, wanted to add it to the list of ports.