### PR TITLE
Return Best Distance

### DIFF
--- a/polylabel.js
+++ b/polylabel.js
@@ -78,7 +78,7 @@ function polylabel(polygon, precision, debug) {
     }
 
     var poleOfInaccessibility = [bestCell.x, bestCell.y];
-    poleOfInaccessibility.distance = bestCell.d || 0;
+    poleOfInaccessibility.distance = bestCell.d;
     return poleOfInaccessibility;
 }
 
@@ -113,7 +113,7 @@ function pointToPolygonDist(x, y, polygon) {
         }
     }
 
-    return (inside ? 1 : -1) * Math.sqrt(minDistSq);
+    return minDistSq === 0 ? 0 : (inside ? 1 : -1) * Math.sqrt(minDistSq);
 }
 
 // get polygon centroid

--- a/polylabel.js
+++ b/polylabel.js
@@ -25,7 +25,11 @@ function polylabel(polygon, precision, debug) {
     var cellSize = Math.min(width, height);
     var h = cellSize / 2;
 
-    if (cellSize === 0) return [minX, minY];
+    if (cellSize === 0) {
+        var degeneratePoleOfInaccessibility = [minX, minY];
+        degeneratePoleOfInaccessibility.distance = 0;
+        return degeneratePoleOfInaccessibility;
+    }
 
     // a priority queue of cells in order of their "potential" (max distance to polygon)
     var cellQueue = new Queue(undefined, compareMax);
@@ -73,7 +77,9 @@ function polylabel(polygon, precision, debug) {
         console.log('best distance: ' + bestCell.d);
     }
 
-    return [bestCell.x, bestCell.y];
+    var poleOfInaccessibility = [bestCell.x, bestCell.y];
+    poleOfInaccessibility.distance = bestCell.d || 0;
+    return poleOfInaccessibility;
 }
 
 function compareMax(a, b) {

--- a/test/test.js
+++ b/test/test.js
@@ -8,28 +8,38 @@ var water2 = require('./fixtures/water2.json');
 
 test('finds pole of inaccessibility for water1 and precision 1', function (t) {
     var p = polylabel(water1, 1);
-    t.same(p, [3865.85009765625, 2124.87841796875]);
+    t.same(p, Object.assign([3865.85009765625, 2124.87841796875], {
+        distance: 288.8493574779127
+    }));
     t.end();
 });
 
 test('finds pole of inaccessibility for water1 and precision 50', function (t) {
     var p = polylabel(water1, 50);
-    t.same(p, [3854.296875, 2123.828125]);
+    t.same(p, Object.assign([3854.296875, 2123.828125], {
+        distance: 278.5795872381558
+    }));
     t.end();
 });
 
 test('finds pole of inaccessibility for water2 and default precision 1', function (t) {
     var p = polylabel(water2);
-    t.same(p, [3263.5, 3263.5]);
+    t.same(p, Object.assign([3263.5, 3263.5], {
+        distance: 960.5
+    }));
     t.end();
 });
 
 test('works on degenerate polygons', function (t) {
     var p = polylabel([[[0, 0], [1, 0], [2, 0], [0, 0]]]);
-    t.same(p, [0, 0]);
+    t.same(p, Object.assign([0, 0], {
+        distance: 0
+    }));
 
     p = polylabel([[[0, 0], [1, 0], [1, 1], [1, 0], [0, 0]]]);
-    t.same(p, [0, 0]);
+    t.same(p, Object.assign([0, 0], {
+        distance: 0
+    }));
 
     t.end();
 });


### PR DESCRIPTION
This PR is a proposed solution for #2.

A fresh take on #14.

Summary of changes:
 * Adds a `distance` property to returned values.
 * Includes changes to tests.
 * Guarantee that the distance value is `0`, not `-0`, for degenerate cases.
 * Guarantee that there is always a value included for `distance` (never gets `undefined`).
 * Stick to ES5 (use `var`, and `Object.assign` in tests instead of rest/spread).

Kindly requesting review @mourner @fil . Feedback welcome!

🙏