### PR TITLE
Format debug distance as float instead of integer.

### DIFF
--- a/polylabel.js
+++ b/polylabel.js
@@ -57,7 +57,7 @@ function polylabel(polygon, precision, debug) {
         // update the best cell if we found a better one
         if (cell.d > bestCell.d) {
             bestCell = cell;
-            if (debug) console.log('found best %d after %d probes', Math.round(1e4 * cell.d) / 1e4, numProbes);
+            if (debug) console.log('found best %f after %d probes', Math.round(1e4 * cell.d) / 1e4, numProbes);
         }
 
         // do not drill down further if there's no chance of a better solution


### PR DESCRIPTION
```
console.log('found best %d after %d probes', Math.round(1e4 * cell.d) / 1e4, numProbes);
```

This prints `cell.d` as `%d` which is an integer. It will print values lower than 1 as just `0`.

Fix: Use `%f` to print decimal.