### PR TITLE
Fix link to Java port

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ int main() {
 - [Shapely](https://github.com/Toblerity/Shapely/blob/master/shapely/algorithms/polylabel.py) (Python)
 - [polylabelr](https://CRAN.R-project.org/package=polylabelr) (R)
 - [polylabel-rs](https://github.com/urschrei/polylabel-rs) (Rust)
-- [polylabel-java] (https://github.com/FreshLlamanade/polylabel-java) (Java)
+- [polylabel-java](https://github.com/FreshLlamanade/polylabel-java) (Java)


### PR DESCRIPTION
Sorry about that, there was an extra space between the name and the URL that prevented the link from displaying correctly. Fixed now