### PR TITLE
Clarify comment for bbox centroid guess

### DIFF
--- a/include/mapbox/polylabel.hpp
+++ b/include/mapbox/polylabel.hpp
@@ -137,7 +137,7 @@ geometry::point<T> polylabel(const geometry::polygon<T>& polygon, T precision = 
     // take centroid as the first best guess
     auto bestCell = getCentroidCell(polygon);
 
-    // special case for rectangular polygons
+    // second guess: bounding box centroid
     Cell<T> bboxCell(envelope.min + size / 2.0, 0, polygon);
     if (bboxCell.d > bestCell.d) {
         bestCell = bboxCell;

--- a/polylabel.js
+++ b/polylabel.js
@@ -44,7 +44,7 @@ function polylabel(polygon, precision, debug) {
     // take centroid as the first best guess
     var bestCell = getCentroidCell(polygon);
 
-    // special case for rectangular polygons
+    // second guess: bounding box centroid
     var bboxCell = new Cell(minX + width / 2, minY + height / 2, 0, polygon);
     if (bboxCell.d > bestCell.d) bestCell = bboxCell;
 


### PR DESCRIPTION
The original comment "special case for rectangular polygons" isn't
accurate, as this guess could apply to any polygon (for example, a
circle).

Resolves #72