### PR TITLE
Add php-polylabel port to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ int main() {
 - [polylabelr](https://CRAN.R-project.org/package=polylabelr) (R)
 - [polylabel-rs](https://github.com/urschrei/polylabel-rs) (Rust)
 - [polylabel-java](https://github.com/FreshLlamanade/polylabel-java) (Java)
+- [php-polylabel](https://github.com/dliebner/php-polylabel) (PHP)


### PR DESCRIPTION
I added a [PHP port](https://github.com/dliebner/php-polylabel) of Polylabel. It uses [SplPriorityQueue](https://www.php.net/manual/en/class.splpriorityqueue.php) for the priority queue. It contains basic unit tests that all pass.