### PR TITLE
Publish on NPM via GHA Trusted Publishing

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,0 +1,17 @@
+name: Publish
+on:
+  push:
+    tags: ['v*']
+permissions:
+  id-token: write
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm-release
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - run: npm ci
+      - run: npm publish --access public


### PR DESCRIPTION
Adds a minimal GitHub Actions workflow for publishing on NPM via Trusted Publishing. Supercedes #126.

**Configuring the environment**: 

- GitHub repo settings → Environments → New environment → `npm-release`
- Selected branches and tags → Add rule → Ref type: Tag -> `v*`

**Releasing with this workflow**:

- `npm version <major|minor|patch>`
- Get the PR green, approved and merged.
- Once everything looks good, `git push --tags` to release.